### PR TITLE
Strings

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CSTParser]]
 deps = ["LibGit2", "Test", "Tokenize"]
-path = "/home/domluna/.julia/dev/CSTParser"
+git-tree-sha1 = "437c93bc191cd55957b3f8dee7794b6131997c56"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "0.5.2+"
+version = "0.5.2"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CSTParser]]
 deps = ["LibGit2", "Test", "Tokenize"]
-git-tree-sha1 = "437c93bc191cd55957b3f8dee7794b6131997c56"
+path = "/home/domluna/.julia/dev/CSTParser"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "0.5.2"
+version = "0.5.2+"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]

--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ Finally, the `PTree` to an `IOBuffer` with `print_tree` which is then consumed a
 
 ### Known Limitations
 
-* https://github.com/ZacLN/CSTParser.jl/issues/93
-* https://github.com/ZacLN/CSTParser.jl/issues/88
-* https://github.com/ZacLN/CSTParser.jl/issues/94
-
 If a comment is at the end of a line of code it will be removed.
 
 ```julia

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -7,7 +7,7 @@ export format
 
 function file_line_ranges(text::String)
     ranges = UnitRange{Int}[]
-    lit_strings = Dict{Int, Tuple{Int,Int,String}}[]
+    lit_strings = Dict{Int, Tuple{Int,Int,String}}()
     for t in CSTParser.Tokenize.tokenize(text)
         if t.kind == Tokens.WHITESPACE
             offset = t.startbyte
@@ -23,18 +23,17 @@ function file_line_ranges(text::String)
             push!(ranges, s:t.startbyte)
         elseif (t.kind == Tokens.TRIPLE_STRING || t.kind == Tokens.STRING) && t.startpos[1] != t.endpos[1]
             offset = t.startbyte
-            lit_strings[offset] = (t.startpos[1], t.endpos[1], t.val)
-
             nls = findall(x -> x == '\n', t.val)
             for nl in nls
                 s = length(ranges) > 0 ? last(ranges[end]) + 1 : 1
                 push!(ranges, s:offset+nl)
             end
-
         elseif t.kind == Tokens.COMMENT
             @info "comment token" t
         end
+
         if (t.kind == Tokens.TRIPLE_STRING || t.kind == Tokens.STRING)
+            lit_strings[t.startbyte] = (t.startpos[1], t.endpos[1], t.val)
         end
     end
     ranges, lit_strings

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -29,7 +29,7 @@ function file_line_ranges(text::String)
                 push!(ranges, s:offset+nl)
             end
         elseif t.kind == Tokens.COMMENT
-            @info "comment token" t
+            #= @info "comment token" t =#
         end
 
         if (t.kind == Tokens.TRIPLE_STRING || t.kind == Tokens.STRING)
@@ -39,28 +39,11 @@ function file_line_ranges(text::String)
     ranges, lit_strings
 end
 
-"""
-Raw literal string representation along
-with the location in the file.
-
-`CSTParser` unescapes strings to mimic behaviour
-of `Meta.parse`. This is problematic for formatting
-strings. 
-
-When a `CSTParser.LITERAL` that is of kind `Tokens.STRING`
-or `Tokens.TRIPLE_STRING` is encountered the value repsented
-in the original token will be used instead of the val in the
-`CSTParser` node.
-"""
-struct LitString
-    startline::Int
-    endline::Int
-    val::String
-end
-
 struct Document
     text::String
     ranges::Vector{UnitRange{Int}}
+    # mapping the offset in the file to the raw literal
+    # string and what lines it starts and ends at.
     lit_strings::Dict{Int, Tuple{Int, Int, String}}
     #= inline_commments::Vector{LitString} =#
 end

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -370,22 +370,18 @@ function nest!(x::PTree{T}, s::State; addlen=0) where T <: Union{CSTParser.Binar
     # If there's no placeholder the binary call is not nestable
     #= @info "ENTER" typeof(x) s.line_offset x.indent length(x) =#
     idx = findlast(n -> is_placeholder(n), x.nodes) 
-    @info "" idx
     line_length = s.line_offset + length(x) + addlen
     if idx !== nothing && line_length > s.max_line_length
         line_offset = s.line_offset
         # idx op is 1 before the placeholder
         idx -= 1
         lens = remaining_length(x.nodes[1:idx])
-        @info "" lens
 
         x.indent = s.line_offset
         s.line_offset += lens[1]
 
         x.nodes[idx+1] = newline
         s.line_offset = x.indent
-
-        #= @info "" s.line_offset x.indent =#
 
         # arg2
         nest!(x.nodes[end], s)

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -1,6 +1,6 @@
 # Nest
 #
-# If the line exceeds the maximum width it will be nested.
+# If the line exceeds the maximum length it will be nested.
 # 
 # This is done by replacing `Placeholder` nodes with `Newline` 
 # nodes and updating the PTree's indent.
@@ -49,7 +49,7 @@ end
 
 function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; addlen=0) where T <: Union{CSTParser.Import,CSTParser.Using,CSTParser.Export}
     #= @info "ENTER" typeof(x) s.line_offset x =#
-    if s.line_offset + length(x) > s.max_width
+    if s.line_offset + length(x) > s.max_line_length
         idx = findfirst(n -> is_placeholder(n), x.nodes)
         # -3 due to the placeholder being ahead of a comma
         # and another node
@@ -67,7 +67,7 @@ function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; addlen=0) where T <: Union
                 # Check if the additional length of the nodes 
                 # before the next placholder warrant a nest.
                 j = i + 1 == length(lens) ? 1 : 2
-                if s.line_offset + sum(lens[i:i+j]) > s.max_width
+                if s.line_offset + sum(lens[i:i+j]) > s.max_line_length
                     x.nodes[i+idx-3] = newline
                     s.line_offset = x.indent
                 else
@@ -90,27 +90,26 @@ function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; addlen=0) where T <: Union
 end
 
 function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; addlen=0) where T <: Union{CSTParser.TupleH,CSTParser.Vect,CSTParser.InvisBrackets,CSTParser.Braces,CSTParser.Parameters}
-    line_width = s.line_offset + length(x) + addlen
+    line_length = s.line_offset + length(x) + addlen
     idx = findlast(n -> is_placeholder(n), x.nodes)
-    #= @info "ENTER" typeof(x) s.line_offset line_width =#
+    #= @info "ENTER" typeof(x) s.line_offset line_length =#
 
-    if idx !== nothing && line_width > s.max_width
+    if idx !== nothing && line_length > s.max_line_length
         x.indent = s.line_offset
         lens = length.(x.nodes)
         has_brackets = x.nodes[1] isa PLeaf{CSTParser.PUNCTUATION}
         has_brackets && (x.indent += 1)
 
         for (i, n) in enumerate(x.nodes)
-            #= @info "" typeof(n) n s.line_offset =#
             if n === newline
                 s.line_offset = x.indent
             elseif is_placeholder(n)
                 # Check if the additional length of the nodes 
                 # before the next placholder warrant a nest.
                 j = i + 1 == length(lens) ? 1 : 2
-                line_width = s.line_offset + sum(lens[i:i+j])
-                i == idx && (line_width += addlen)
-                if line_width > s.max_width
+                line_length = s.line_offset + sum(lens[i:i+j])
+                i == idx && (line_length += addlen)
+                if line_length > s.max_line_length
                     x.nodes[i] = newline
                     s.line_offset = x.indent
                 else
@@ -133,10 +132,10 @@ function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; addlen=0) where T <: Union
 end
 
 function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; addlen=0) where T <: Union{CSTParser.Curly,CSTParser.Call}
-    line_width = s.line_offset + length(x) + addlen
+    line_length = s.line_offset + length(x) + addlen
     idx = findlast(n -> is_placeholder(n), x.nodes)
-    #= @info "ENTER" typeof(x) s.line_offset line_width addlen =#
-    if idx !== nothing && line_width > s.max_width
+    #= @info "ENTER" typeof(x) s.line_offset line_length addlen =#
+    if idx !== nothing && line_length > s.max_line_length
         x.indent = s.line_offset + length(x.nodes[1]) + length(x.nodes[2])
         s.line_offset = x.indent
         lens = length.(x.nodes[3:end])
@@ -148,9 +147,9 @@ function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; addlen=0) where T <: Union
                 # Check if the additional length of the nodes 
                 # before the next placholder warrant a nest.
                 j = i + 1 == length(lens) ? 1 : 2
-                line_width = s.line_offset + sum(lens[i:i+j])
-                i + 2 == idx && (line_width += addlen)
-                if line_width > s.max_width
+                line_length = s.line_offset + sum(lens[i:i+j])
+                i + 2 == idx && (line_length += addlen)
+                if line_length > s.max_line_length
                     x.nodes[i+2] = newline
                     s.line_offset = x.indent
                 else
@@ -172,25 +171,24 @@ function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; addlen=0) where T <: Union
 end
 
 function nest!(x::PTree{CSTParser.EXPR{CSTParser.MacroCall}}, s::State; addlen=0)
-    line_width = s.line_offset + length(x) + addlen
+    line_length = s.line_offset + length(x) + addlen
     idx = findlast(n -> is_placeholder(n), x.nodes)
-    #= @info "ENTER" typeof(x) s.line_offset line_width addlen =#
-    if idx !== nothing && line_width > s.max_width && !(x.nodes[1] isa PTree{CSTParser.EXPR{CSTParser.GlobalRefDoc}})
+    #= @info "ENTER" typeof(x) s.line_offset line_length addlen =#
+    if idx !== nothing && line_length > s.max_line_length && !(x.nodes[1] isa PTree{CSTParser.EXPR{CSTParser.GlobalRefDoc}})
         x.indent = s.line_offset + length(x.nodes[1]) + length(x.nodes[2])
         s.line_offset = x.indent
         lens = length.(x.nodes[3:end])
 
         for (i, n) in enumerate(x.nodes[3:end])
-            #= @info "" typeof(n) n s.line_offset =#
             if n === newline
                 s.line_offset = x.indent
             elseif is_placeholder(n) 
                 # Check if the additional length of the nodes 
                 # before the next placholder warrant a nest.
                 j = i + 1 == length(lens) ? 1 : 2
-                line_width = s.line_offset + sum(lens[i:i+j])
-                i + 2 == idx && (line_width += addlen)
-                if line_width > s.max_width
+                line_length = s.line_offset + sum(lens[i:i+j])
+                i + 2 == idx && (line_length += addlen)
+                if line_length > s.max_line_length
                     x.nodes[i+2] = newline
                     s.line_offset = x.indent
                 else
@@ -214,11 +212,11 @@ end
 # A where B
 #
 # nest B prior to nesting A
-# only nest A if the line still exceeds the maximum width
+# only nest A if the line still exceeds the maximum length
 function nest!(x::PTree{CSTParser.WhereOpCall}, s::State; addlen=0)
     #= @info "ENTER" typeof(x) s.line_offset x =#
-    line_width = s.line_offset + length(x) + addlen
-    if line_width > s.max_width
+    line_length = s.line_offset + length(x) + addlen
+    if line_length > s.max_line_length
         line_offset = s.line_offset
         # after "A where "
         idx = findfirst(n -> is_placeholder(n), x.nodes)
@@ -237,10 +235,10 @@ function nest!(x::PTree{CSTParser.WhereOpCall}, s::State; addlen=0)
             elseif is_placeholder(n) 
                 ph_offset = max(ph_offset, s.line_offset)
                 j = i + 1 == length(Blens) ? 1 : 2
-                line_width = s.line_offset + sum(Blens[i:i+j])
-                #= line_width = s.line_offset + Blens[i] =#
-                i + 2 == length(Blens) && (line_width += addlen)
-                if line_width > s.max_width
+                line_length = s.line_offset + sum(Blens[i:i+j])
+                #= line_length = s.line_offset + Blens[i] =#
+                i + 2 == length(Blens) && (line_length += addlen)
+                if line_length > s.max_line_length
                     x.nodes[i+idx] = newline
                     s.line_offset = x.indent
                 end
@@ -317,8 +315,8 @@ end
 # E2
 function nest!(x::PTree{CSTParser.ConditionalOpCall}, s::State; addlen=0)
     #= @info "ENTER" typeof(x) s.line_offset =#
-    line_width = s.line_offset + length(x) + addlen
-    if line_width > s.max_width
+    line_length = s.line_offset + length(x) + addlen
+    if line_length > s.max_line_length
         idx1 = findfirst(n -> is_placeholder(n), x.nodes)
         idx2 = findlast(n -> is_placeholder(n), x.nodes)
         Clens = remaining_length(x.nodes[1:idx1])
@@ -332,7 +330,7 @@ function nest!(x::PTree{CSTParser.ConditionalOpCall}, s::State; addlen=0)
 
         # E1
         s.line_offset = line_offset + Clens[1]
-        if s.line_offset + E1lens[1] > s.max_width
+        if s.line_offset + E1lens[1] > s.max_line_length
             x.nodes[idx1] = newline
             s.line_offset = x.indent
         end
@@ -369,15 +367,17 @@ end
 # arg1 op
 # arg2
 function nest!(x::PTree{T}, s::State; addlen=0) where T <: Union{CSTParser.BinaryOpCall,CSTParser.BinarySyntaxOpCall}
-    #= @info "ENTER" typeof(x) s.line_offset x.indent length(x) =#
     # If there's no placeholder the binary call is not nestable
+    #= @info "ENTER" typeof(x) s.line_offset x.indent length(x) =#
     idx = findlast(n -> is_placeholder(n), x.nodes) 
-    line_width = s.line_offset + length(x) + addlen
-    if idx !== nothing && line_width > s.max_width
+    @info "" idx
+    line_length = s.line_offset + length(x) + addlen
+    if idx !== nothing && line_length > s.max_line_length
         line_offset = s.line_offset
         # idx op is 1 before the placeholder
         idx -= 1
         lens = remaining_length(x.nodes[1:idx])
+        @info "" lens
 
         x.indent = s.line_offset
         s.line_offset += lens[1]

--- a/src/print.jl
+++ b/src/print.jl
@@ -14,6 +14,9 @@ function print_tree(io::IOBuffer, x::PTree, s::State)
                 write(io, repeat(" ", x.nodes[i+1].indent))
             elseif x.nodes[i+1] isa NotCode
                 write(io, repeat(" ", x.nodes[i+1].indent))
+            elseif x.nodes[i+1] isa PTree{CSTParser.EXPR{CSTParser.StringH}}
+                write(io, repeat(" ", x.nodes[i+1].indent))
+            elseif is_empty_lit(x.nodes[i+1])
             else
                 write(io, ws)
             end
@@ -31,6 +34,8 @@ function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{CSTParser.If}}, s::Sta
                 write(io, repeat(" ", x.nodes[i+1].indent))
             elseif x.nodes[i+1] isa NotCode
                 write(io, repeat(" ", x.nodes[i+1].indent))
+            elseif x.nodes[i+1] isa PTree{CSTParser.EXPR{CSTParser.StringH}}
+                write(io, repeat(" ", x.nodes[i+1].indent))
             elseif x.nodes[i+1] isa PLeaf{CSTParser.KEYWORD}
                 v = x.nodes[i+1].text
                 if n1 isa PLeaf{CSTParser.KEYWORD} && n1.text == "if " 
@@ -42,6 +47,7 @@ function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{CSTParser.If}}, s::Sta
                 else
                     write(io, ws)
                 end
+            elseif is_empty_lit(x.nodes[i+1])
             else
                 write(io, ws)
             end
@@ -51,13 +57,10 @@ end
 
 function print_tree(io::IOBuffer, x::NotCode, s::State)
     r = x.startline:x.endline
-    #= @info "PRINTING NotCode" r x.indent x =#
     ws = repeat(" ", x.indent)
-
     for (i, l) in enumerate(r)
         v = s.doc.text[s.doc.ranges[l]]
-        idx = findfirst(x -> !isspace(x), v)
-        #= @info "" l v idx =#
+        idx = findfirst(c -> !isspace(c), v)
         if idx === nothing
             v == "\n" && (write(io, v); write(io, ws))
         elseif v[idx] == '#'

--- a/src/print.jl
+++ b/src/print.jl
@@ -37,7 +37,7 @@ function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{CSTParser.If}}, s::Sta
                     write(io, ws)
                 elseif v == "elseif" || v == "else"
                     if ws != ""
-                        write(io, repeat(" ", x.indent - s.indent_width))
+                        write(io, repeat(" ", x.indent - s.indent_size))
                     end
                 else
                     write(io, ws)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -494,12 +494,12 @@ end
 end
 
 @testset "strings" begin
-    #= str = """ =#
-    #= \""" =#
-    #= Interpolate using `\\\$` =#
-    #= \""" =#
-    #= """ =#
-    #= @test format(str) == str =#
+    str = """
+    \"""
+    Interpolate using `\\\$`
+    \"""
+    """
+    @test format(str) == str
 
     str = """error("foo\\n\\nbar")"""
     @test format(str) == str

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -515,7 +515,7 @@ end
     begin
         s = \"\"\"This is a multiline string.
                   This is another line.
-                      Look another 1 that is indented a bit.
+                      Look an indented line.
 
                       cool!\"\"\"
     end"""
@@ -524,7 +524,7 @@ end
     begin
     s = \"\"\"This is a multiline string.
               This is another line.
-                  Look another 1 that is indented a bit.
+                  Look an indented line.
 
                   cool!\"\"\"
     end""") == str

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,9 @@ using JLFmt: format, Document, State, pretty, nest!
 using CSTParser
 using Test
 
-function run_nest(text::String, max_width::Int)
+function run_nest(text::String, max_line_length::Int)
     d = Document(text)
-    s = State(d, 4, 0, 1, 0, max_width)
+    s = State(d, 4, 0, 1, 0, max_line_length)
     x = CSTParser.parse(text, true)
     t = pretty(x, s)
     nest!(t, s)
@@ -458,39 +458,6 @@ end
     function f()
         20
     end""") == str
-
-    # tests indentation and correctly formatting a docstring with escapes
-    #
-    # NOTE: At the moment indentation is printed after a newline even if the
-    # next line is a newline. I added some indentation so this passes for now.
-    str = """
-       begin
-           \"""
-               f
-
-           docstring for f
-           :(function \$(dict[:name]){\$(all_params...)}(\$(dict[:args]...);
-                                                \$(dict[:kwargs]...))::\$rtype
-           \$(dict[:body])
-           \"""
-           function f()
-               100
-           end
-       end"""
-    @test format("""
-begin
-\"""
-   f
-
-docstring for f
-:(function \$(dict[:name]){\$(all_params...)}(\$(dict[:args]...);
-                                    \$(dict[:kwargs]...))::\$rtype
-\$(dict[:body])
-\"""
-function f()
-100
-end
-end""") == str
 end
 
 @testset "strings" begin
@@ -515,7 +482,7 @@ end
     begin
         s = \"\"\"This is a multiline string.
                   This is another line.
-                      Look an indented line.
+                      Look another 1 that is indented a bit.
 
                       cool!\"\"\"
     end"""
@@ -524,7 +491,7 @@ end
     begin
     s = \"\"\"This is a multiline string.
               This is another line.
-                  Look an indented line.
+                  Look another 1 that is indented a bit.
 
                   cool!\"\"\"
     end""") == str
@@ -776,96 +743,96 @@ end
         10
         20
     end"""
-    @test format("function f(arg1::A,key1=val1;key2=val2) where {A,F{B,C}} 10; 20 end", max_width=1) == str
+    @test format("function f(arg1::A,key1=val1;key2=val2) where {A,F{B,C}} 10; 20 end", max_line_length=1) == str
 
     str = """
     a |
     b |
     c |
     d"""
-    @test format("a | b | c | d", max_width=1) == str
+    @test format("a | b | c | d", max_line_length=1) == str
 
 
     str = """
     a, b,
     c, d"""
-    @test format("a, b, c, d", max_width=6) == str
+    @test format("a, b, c, d", max_line_length=6) == str
 
     str = """
     (a, b,
      c, d)"""
-    @test format("(a, b, c, d)", max_width=7) == str
+    @test format("(a, b, c, d)", max_line_length=7) == str
 
     str = """
     [a,
      b,
      c,
      d]"""
-    @test format("[a, b, c, d]", max_width=1) == str
+    @test format("[a, b, c, d]", max_line_length=1) == str
 
     str = """
     cond ?
     e1 :
     e2"""
-    @test format("cond ? e1 : e2", max_width=1) == str
+    @test format("cond ? e1 : e2", max_line_length=1) == str
 
     str = """
     cond ? e1 :
     e2"""
-    @test format("cond ? e1 : e2", max_width=12) == str
+    @test format("cond ? e1 : e2", max_line_length=12) == str
 
     str = """
     cond1 ? e1 :
     cond2 ? e2 :
     cond3 ? e3 :
     e4"""
-    @test format("cond1 ? e1 : cond2 ? e2 : cond3 ? e3 : e4", max_width=13) == str
+    @test format("cond1 ? e1 : cond2 ? e2 : cond3 ? e3 : e4", max_line_length=13) == str
 
     str = """
     export a,
            b"""
-    @test format("export a,b", max_width=1) == str
+    @test format("export a,b", max_line_length=1) == str
 
     str = """
     using a,
           b"""
-    @test format("using a,b", max_width=1) == str
+    @test format("using a,b", max_line_length=1) == str
 
     str = """
     using M: a,
              b"""
-    @test format("using M:a,b", max_width=1) == str
+    @test format("using M:a,b", max_line_length=1) == str
 
     str = """
     import M1.M2.M3: a,
                      b"""
-    @test format("import M1.M2.M3:a,b", max_width=1) == str
+    @test format("import M1.M2.M3:a,b", max_line_length=1) == str
 
     str = """
     foo() = (one,
              x -> (true, false))"""
-    @test format("foo() = (one, x -> (true, false))", max_width=30) == str
+    @test format("foo() = (one, x -> (true, false))", max_line_length=30) == str
 
     str = """
     foo() = (one,
              x -> (true,
                    false))"""
-    @test format("foo() = (one, x -> (true, false))", max_width=20) == str
+    @test format("foo() = (one, x -> (true, false))", max_line_length=20) == str
 
     str = """
     @somemacro function (fcall_ |
                          fcall_)
         body_
     end"""
-    @test format("@somemacro function (fcall_ | fcall_) body_ end", max_width=1) == str
+    @test format("@somemacro function (fcall_ | fcall_) body_ end", max_line_length=1) == str
 
     str = "(a; b; c)"
-    @test format("(a;b;c)", max_width=100) == str
-    @test format("(a;b;c)", max_width=1) == str
+    @test format("(a;b;c)", max_line_length=100) == str
+    @test format("(a;b;c)", max_line_length=1) == str
 
     str = "(x for x in 1:10)"
-    @test format("(x   for x  in  1 : 10)", max_width=100) == str
-    @test format("(x   for x  in  1 : 10)", max_width=1) == str
+    @test format("(x   for x  in  1 : 10)", max_line_length=100) == str
+    @test format("(x   for x  in  1 : 10)", max_line_length=1) == str
 
 end
 
@@ -984,57 +951,57 @@ end
     f(a,
       @g(b, c),
       d)"""
-    @test format("f(a, @g(b, c), d)", max_width=11) == str
+    @test format("f(a, @g(b, c), d)", max_line_length=11) == str
 
     str = """
     f(a,
       @g(b,
          c),
       d)"""
-    @test format("f(a, @g(b, c), d)", max_width=10) == str
+    @test format("f(a, @g(b, c), d)", max_line_length=10) == str
 
     str = """
     (a,
      (b,
       c),
      d)"""
-    @test format("(a, (b, c), d)", max_width=7) == str
+    @test format("(a, (b, c), d)", max_line_length=7) == str
 
     str = """
     (a,
      {b,
       c},
      d)"""
-    @test format("(a, {b, c}, d)", max_width=6) == str
+    @test format("(a, {b, c}, d)", max_line_length=6) == str
 
     str = """
     a,
     (b,
      c), d"""
-    @test format("a, (b, c), d", max_width=6) == str
+    @test format("a, (b, c), d", max_line_length=6) == str
 
     str = """
     a,
     (b, c),
     d"""
-    @test format("a, (b, c), d", max_width=7) == str
+    @test format("a, (b, c), d", max_line_length=7) == str
 
     str = """
     (var1,
      var2) &&
     var3"""
-    @test format("(var1,var2) && var3", max_width=14) == str
+    @test format("(var1,var2) && var3", max_line_length=14) == str
 
     str = """
     (var1, var2) &&
     var3"""
-    @test format("(var1,var2) && var3", max_width=15) == str
+    @test format("(var1,var2) && var3", max_line_length=15) == str
 
     str = """
     (var1, var2) ?
     (var3, var4) :
     var5"""
-    @test format("(var1,var2) ? (var3,var4) : var5", max_width=14) == str
+    @test format("(var1,var2) ? (var3,var4) : var5", max_line_length=14) == str
 
     str = """
     (var1,
@@ -1042,29 +1009,29 @@ end
     (var3,
      var4) :
     var5"""
-    @test format("(var1,var2) ? (var3,var4) : var5", max_width=13) == str
+    @test format("(var1,var2) ? (var3,var4) : var5", max_line_length=13) == str
 
     str = """
     (var1, var2) ? (var3, var4) :
     var5"""
-    @test format("(var1,var2) ? (var3,var4) : var5", max_width=30) == str
+    @test format("(var1,var2) ? (var3,var4) : var5", max_line_length=30) == str
 
     str = """
     (var1, var2) ?
     (var3, var4) :
     var5"""
-    @test format("(var1,var2) ? (var3,var4) : var5", max_width=29) == str
+    @test format("(var1,var2) ? (var3,var4) : var5", max_line_length=29) == str
 
     str = """
     f(var1::A, var2::B) where {A,
                                B}"""
-    @test format("f(var1::A, var2::B) where {A,B}", max_width=30) == str
+    @test format("f(var1::A, var2::B) where {A,B}", max_line_length=30) == str
 
     str = """
     f(var1::A,
       var2::B) where {A,
                       B}"""
-    @test format("f(var1::A, var2::B) where {A,B}", max_width=28) == str
+    @test format("f(var1::A, var2::B) where {A,B}", max_line_length=28) == str
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -478,19 +478,19 @@ end
            end
        end"""
     @test format("""
-       begin
-       \"""
-           f
+begin
+\"""
+   f
 
-       docstring for f
-       :(function \$(dict[:name]){\$(all_params...)}(\$(dict[:args]...);
-                                            \$(dict[:kwargs]...))::\$rtype
-       \$(dict[:body])
-       \"""
-       function f()
-       100
-       end
-       end""") == str
+docstring for f
+:(function \$(dict[:name]){\$(all_params...)}(\$(dict[:args]...);
+                                    \$(dict[:kwargs]...))::\$rtype
+\$(dict[:body])
+\"""
+function f()
+100
+end
+end""") == str
 end
 
 @testset "strings" begin
@@ -511,23 +511,23 @@ end
     x"""
     @test format("\"\\\\\" x") == str
 
-    #= str = """ =#
-    #= begin =#
-    #=     s = \"\"\"This is a multiline string. =#
-    #=               This is another line. =#
-    #=                   Look another 1 that is indented a bit. =#
-    #=  =#
-    #=                   cool!\"\"\" =#
-    #= end""" =#
-    #=  =#
-    #= @test format(""" =#
-    #= begin =#
-    #= s = \"\"\"This is a multiline string. =#
-    #=           This is another line. =#
-    #=               Look another 1 that is indented a bit. =#
-    #=  =#
-    #=               cool!\"\"\" =#
-    #= end""") == str =#
+    str = """
+    begin
+        s = \"\"\"This is a multiline string.
+                  This is another line.
+                      Look another 1 that is indented a bit.
+
+                      cool!\"\"\"
+    end"""
+
+    @test format("""
+    begin
+    s = \"\"\"This is a multiline string.
+              This is another line.
+                  Look another 1 that is indented a bit.
+
+                  cool!\"\"\"
+    end""") == str
 end
 
 @testset "notcode" begin


### PR DESCRIPTION
Fixes 

https://github.com/domluna/JLFmt.jl/issues/6

and circumvents

https://github.com/ZacLN/CSTParser.jl/issues/88
https://github.com/ZacLN/CSTParser.jl/issues/94

The approach is to create a dict of the file byte offset to STRING and TRIPLE_STRING token's string value, start line and end lines. When a StringH or string LITERAL node is encountered instead of using the value(s) from the node itself, the raw string value is looked up from the dict and processed accordingly. I'm pretty sure something similar could be done for inline comments but I'll save that for another PR.

Extra:

* renamed `max_width` to `max_line_length` and `indent_width` to `indent_size`
* empty string literals no longer trigger indentation.