### PR TITLE
Refactor

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -4,10 +4,10 @@
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CSTParser]]
-deps = ["LibGit2", "Test", "Tokenize"]
-git-tree-sha1 = "437c93bc191cd55957b3f8dee7794b6131997c56"
+deps = ["Tokenize"]
+git-tree-sha1 = "376a39f1862000442011390f1edf5e7f4dcc7142"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "0.5.2"
+version = "0.6.0"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -17,19 +17,12 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[LibGit2]]
-uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
-
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
-[[Printf]]
-deps = ["Unicode"]
-uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[Random]]
 deps = ["Serialization"]
@@ -46,10 +39,6 @@ deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[Tokenize]]
-deps = ["Printf", "Test"]
-git-tree-sha1 = "3e83f60b74911d3042d3550884ca2776386a02b8"
+git-tree-sha1 = "0de343efc07da00cd449d5b04e959ebaeeb3305d"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.3"
-
-[[Unicode]]
-uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "0.5.4"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,7 +5,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "376a39f1862000442011390f1edf5e7f4dcc7142"
+git-tree-sha1 = "72b1c58da3c58ded0dcfb07df4d80bdc1a0bcf82"
+repo-rev = "master"
+repo-url = "https://github.com/julia-vscode/CSTParser.jl.git"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
 version = "0.6.0"
 

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -38,7 +38,7 @@ function file_line_ranges(text::AbstractString)
             comments[t.startpos[1]] = t.val
         end
     end
-    # @info "" lit_strings comments
+    @info "" lit_strings comments
     ranges, lit_strings, comments
 end
 

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -38,7 +38,7 @@ function file_line_ranges(text::AbstractString)
             comments[t.startpos[1]] = t.val
         end
     end
-    # @info "" lit_strings
+    # @info "" lit_strings comments
     ranges, lit_strings, comments
 end
 
@@ -74,7 +74,7 @@ end
 @inline cursor_loc(s::State) = cursor_loc(s, s.offset)
 
 include("pretty.jl")
-# include("nest.jl")
+include("nest.jl")
 include("print.jl")
 
 """
@@ -95,22 +95,24 @@ function format(text::AbstractString, indent_size, print_width)
     s = State(d, indent_size, 0, 1, 0, print_width)
     x = CSTParser.parse(text, true)
     t = pretty(x, s)
-    # nest!(t, s)
-    #
+    nest!(t, s)
+
     # @info "" t
 
     io = IOBuffer()
     # Print comments and whitespace before code.
-    # if t.startline > 1
-    #     print_tree(io, Notcode(1, t.startline-1, 0), s)
-    #     print_tree(io, Newline(), s)
-    # end
+    if t.startline > 1
+        print_tree(io, Notcode(1, t.startline-1, 0), s)
+        print_tree(io, Newline(), s)
+    end
+
     print_tree(io, t, s)
+
     # Print comments and whitespace after code.
-    # if t.endline < length(s.doc.ranges)
-    #     print_tree(io, Newline(), s)
-    #     print_tree(io, Notcode(t.endline+1, length(s.doc.ranges), 0), s)
-    # end
+    if t.endline < length(s.doc.ranges)
+        print_tree(io, Newline(), s)
+        print_tree(io, Notcode(t.endline+1, length(s.doc.ranges), 0), s)
+    end
 
     String(take!(io))
 end

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -74,7 +74,7 @@ end
 @inline cursor_loc(s::State) = cursor_loc(s, s.offset)
 
 include("pretty.jl")
-include("nest.jl")
+# include("nest.jl")
 include("print.jl")
 
 """
@@ -95,20 +95,22 @@ function format(text::AbstractString, indent_size, print_width)
     s = State(d, indent_size, 0, 1, 0, print_width)
     x = CSTParser.parse(text, true)
     t = pretty(x, s)
-    nest!(t, s)
+    # nest!(t, s)
+    #
+    # @info "" t
 
     io = IOBuffer()
     # Print comments and whitespace before code.
-    if t.startline > 1
-        print_tree(io, NotCode(1, t.startline-1, 0), s)
-        print_tree(io, newline, s)
-    end
+    # if t.startline > 1
+    #     print_tree(io, Notcode(1, t.startline-1, 0), s)
+    #     print_tree(io, Newline(), s)
+    # end
     print_tree(io, t, s)
     # Print comments and whitespace after code.
-    if t.endline < length(s.doc.ranges)
-        print_tree(io, newline, s)
-        print_tree(io, NotCode(t.endline+1, length(s.doc.ranges), 0), s)
-    end
+    # if t.endline < length(s.doc.ranges)
+    #     print_tree(io, Newline(), s)
+    #     print_tree(io, Notcode(t.endline+1, length(s.doc.ranges), 0), s)
+    # end
 
     String(take!(io))
 end

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -59,6 +59,9 @@ mutable struct State
     offset::Int
     line_offset::Int
     print_width::Int
+
+    # whether to nest &&, ||
+    # nest_lazy::Bool
 end
 
 @inline nspaces(s::State) = s.indent_size * s.indents

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -38,7 +38,7 @@ function file_line_ranges(text::AbstractString)
             comments[t.startpos[1]] = t.val
         end
     end
-    @info "" lit_strings comments
+    # @info "" lit_strings comments
     ranges, lit_strings, comments
 end
 

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -55,16 +55,13 @@ Document(s::AbstractString) = Document(s, file_line_ranges(s)...)
 mutable struct State
     doc::Document
     indent_size::Int
-    indents::Int
+    indent::Int
     offset::Int
     line_offset::Int
     print_width::Int
-
-    # whether to nest &&, ||
-    # nest_lazy::Bool
 end
 
-@inline nspaces(s::State) = s.indent_size * s.indents
+@inline nspaces(s::State) = s.indent
 
 @inline function cursor_loc(s::State, offset::Int)
     for (l, r) in enumerate(s.doc.ranges)

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -94,6 +94,8 @@ function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; extra_width=0) where T <: 
         line_offset = s.line_offset
         x.indent += s.indent_size
 
+        @info "" x.indent s.line_offset
+
         for (i, n) in enumerate(x.nodes)
             if n === newline
                 s.line_offset = x.indent
@@ -298,20 +300,12 @@ function nest!(x::PTree{T}, s::State; extra_width=0) where T <: Union{CSTParser.
     if idx !== nothing && line_width > s.print_width
         line_offset = s.line_offset
         lens = remaining_lengths(x.nodes[1:idx-1])
-
-        x.indent = s.line_offset
-        s.line_offset += lens[1]
-
         x.nodes[idx] = newline
-        # Only true if CSTParser.defines_function was true
+
         if x.nodes[idx-1].text == "="
             s.line_offset = x.indent + s.indent_size
-            # insert additional whitespace nodes
-            for _ in 1:s.indent_size
-                insert!(x.nodes, idx+1, whitespace)
-            end
         else
-            s.line_offset = x.indent
+            x.indent = s.line_offset
         end
 
         # arg2

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -111,13 +111,16 @@ function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; extra_width=0, align_start
     line_width = s.line_offset + length(x) + extra_width
     idx = findlast(n -> is_placeholder(n), x.nodes)
     if idx !== nothing && line_width > s.print_width
-        line_offset = s.line_offset
-        if align_start != -1
-            line_offset = align_start
-            x.indent = line_offset + s.indent_size
-        else
-            x.indent = is_opener(x.nodes[1]) ? line_offset + 1 : line_offset
-        end
+        # line_offset = s.line_offset
+        # if align_start != -1
+        #     line_offset = align_start
+        #     x.indent = line_offset + s.indent_size
+        # else
+        #     x.indent = is_opener(x.nodes[1]) ? line_offset + 1 : line_offset
+        # end
+
+        line_offset = x.indent
+        x.indent += s.indent_size
 
         for (i, n) in enumerate(x.nodes)
             if n === newline
@@ -146,14 +149,17 @@ function nest!(x::PTree{CSTParser.EXPR{T}}, s::State; extra_width=0, align_start
     line_width = s.line_offset + length(x) + extra_width
     idx = findlast(n -> is_placeholder(n), x.nodes)
     if idx !== nothing && line_width > s.print_width
-        line_offset = s.line_offset
         name_width = length(x.nodes[1]) + length(x.nodes[2])
-        if align_start != -1
-            line_offset = align_start
-            x.indent = line_offset + s.indent_size
-        else
-            x.indent = line_offset + min(name_width, s.indent_size)
-        end
+        # line_offset = s.line_offset
+        # if align_start != -1
+        #     line_offset = align_start
+        #     x.indent = line_offset + s.indent_size
+        # else
+        #     x.indent = line_offset + min(name_width, s.indent_size)
+        # end
+
+        line_offset = x.indent
+        x.indent += s.indent_size
 
         for (i, n) in enumerate(x.nodes)
             if n === newline

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -301,10 +301,11 @@ function nest!(x::PTree{T}, s::State; extra_width=0) where T <: Union{CSTParser.
         @info "START" s.line_offset
         line_offset = s.line_offset
         lens = remaining_lengths(x.nodes[1:idx-1])
-        x.nodes[idx] = newline
+        x.nodes[idx-1] = newline
 
-        if x.nodes[idx-1].text == "="
+        if x.nodes[idx-2].text == "="
             s.line_offset = x.indent + s.indent_size
+            x.nodes[idx] = Whitespace(s.indent_size)
         else
             x.indent = s.line_offset
         end
@@ -314,7 +315,11 @@ function nest!(x::PTree{T}, s::State; extra_width=0) where T <: Union{CSTParser.
 
         # arg1 op
         s.line_offset = line_offset
-        nest!(x.nodes[1], s, extra_width=lens[2])
+        @info "" s.line_offset lens[2] x.nodes[idx] x.nodes[2:3]
+        # nest!(x.nodes[1], s, extra_width=lens[2])
+        # extra_width for the op
+        extra_width = length(x.nodes[2]) + length(x.nodes[3])
+        nest!(x.nodes[1], s, extra_width=extra_width)
         for n in x.nodes[2:idx-1]
             nest!(n, s)
         end

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -31,8 +31,8 @@ end
 # Used to correctly reset the State's line_offset. 
 reset_line_offset(_, _) = nothing
 reset_line_offset(x::AbstractPLeaf, s::State) = (s.line_offset += length(x); nothing)
-nest!(x::AbstractPLeaf, s::State; extra_width=0) = (s.line_offset += length(x); nothing)
 
+nest!(x::AbstractPLeaf, s::State; extra_width=0) = (s.line_offset += length(x); nothing)
 function nest!(x::PTree, s::State; extra_width=0)
     for (i, n) in enumerate(x.nodes)
         if n === newline && x.nodes[i+1] isa PTree{CSTParser.EXPR{CSTParser.Block}}
@@ -298,6 +298,7 @@ function nest!(x::PTree{T}, s::State; extra_width=0) where T <: Union{CSTParser.
     idx = findlast(n -> is_placeholder(n), x.nodes) 
     line_width = s.line_offset + length(x) + extra_width
     if idx !== nothing && line_width > s.print_width
+        @info "START" s.line_offset
         line_offset = s.line_offset
         lens = remaining_lengths(x.nodes[1:idx-1])
         x.nodes[idx] = newline
@@ -318,7 +319,9 @@ function nest!(x::PTree{T}, s::State; extra_width=0) where T <: Union{CSTParser.
             nest!(n, s)
         end
 
+        @info "" s.line_offset
         walk(reset_line_offset, x, s)
+        @info "" s.line_offset
     else
         for (i, n) in enumerate(x.nodes)
             if n === newline

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -334,6 +334,7 @@ function p_literal(x, s; include_quotes=true)
     line = s.doc.text[s.doc.ranges[startline]]
     fc = findfirst(c -> !isspace(c), line)-1
     ns = max(0, nspaces(s) - fc)
+    @info "" loc0[2]
 
     if !include_quotes
         idx = startswith(str, "\"\"\"") ? 4 : 2
@@ -352,10 +353,15 @@ function p_literal(x, s; include_quotes=true)
 
     t = PTree(CSTParser.StringH, -1, -1, ns, 0, nothing, PTree[], Ref(x))
     for (i, l) in enumerate(lines)
+        @info "line" l
         ln = startline + i - 1
         tt = PTree(CSTParser.LITERAL, ln, ln, nspaces(s), length(l), l, nothing, nothing)
         add_node!(t, tt)
     end
+    # The length of this node is the length of
+    # the longest string
+    t.len = maximum(length.(lines))
+    @info "" t
     t
 end
 
@@ -391,6 +397,9 @@ function p_stringh(x, s; include_quotes=true)
         tt = PTree(CSTParser.LITERAL, ln, ln, nspaces(s), length(l), l, nothing, nothing)
         add_node!(t, tt)
     end
+    # The length of this node is the length of
+    # the longest string
+    t.len = maximum(length.(lines))
     t
 end
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -50,7 +50,9 @@ PLeaf(::T, startline::Int, endline::Int, text::AbstractString) where T =
     PLeaf{T}(startline, endline, text, 0)
 Base.length(x::PLeaf) = length(x.text)
 
-const empty_start = PLeaf{CSTParser.LITERAL}(1, 1, "", 0)
+is_empty_start(_) = false
+is_empty_start(x::PLeaf{CSTParser.LITERAL}) =
+    x.startline == 1 && x.endline == 1 && x.text == ""
 
 mutable struct PTree{T}
     startline::Int
@@ -122,7 +124,7 @@ function pretty(x::T, s::State) where T <: Union{AbstractVector,CSTParser.Abstra
     t = PTree(x, nspaces(s))
     for a in x
         n = pretty(a, s)
-        n === empty_start && (continue)
+        is_empty_start(n) && (continue)
         add_node!(t, n, join_lines=true)
     end
     t
@@ -132,7 +134,7 @@ function pretty(x::CSTParser.EXPR{CSTParser.FileH}, s::State)
     t = PTree(x, nspaces(s))
     for a in x
         n = pretty(a, s)
-        n === empty_start && (continue)
+        is_empty_start(n) && (continue)
         add_node!(t, n)
     end
     t

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -324,6 +324,8 @@ function p_literal(x, s; include_quotes=true)
     # So we'll just look at the source directly!
     startline, endline, str = s.doc.lit_strings[s.offset-1]
 
+    @info "" str
+
     # Since a line of a multiline string can already
     # have it's own indentation we check if it needs
     # additional indentation by comparing the number
@@ -971,7 +973,7 @@ function p_invisbrackets(x, s)
     t = PTree(x, nspaces(s))
     multi_arg = length(x) > 4
 
-    multi_arg && (s.indent += s.indent_size)
+    # multi_arg && (s.indent += s.indent_size)
     for (i, a) in enumerate(x)
         # @info "" a.typ === CSTParser.Block
         n = a.typ === CSTParser.Block ? p_block(a, s, from_quote=true) : pretty(a, s)
@@ -988,7 +990,7 @@ function p_invisbrackets(x, s)
             add_node!(t, n, join_lines=true)
         end
     end
-    multi_arg && (s.indent -= s.indent_size)
+    # multi_arg && (s.indent -= s.indent_size)
     t
 end
 
@@ -1002,7 +1004,7 @@ function p_tuple(x, s)
         multi_arg = true
     end
 
-    multi_arg && (s.indent += s.indent_size)
+    # multi_arg && (s.indent += s.indent_size)
     for (i, a) in enumerate(x)
         n = pretty(a, s)
         if is_opener(n) && multi_arg
@@ -1018,7 +1020,7 @@ function p_tuple(x, s)
             add_node!(t, n, join_lines=true)
         end
     end
-    multi_arg && (s.indent -= s.indent_size)
+    # multi_arg && (s.indent -= s.indent_size)
     t
 end
 
@@ -1029,7 +1031,7 @@ function p_braces(x, s)
     multi_arg = length(x) > 4
     # @info "" multi_arg typeof(x)
 
-    multi_arg && (s.indent += s.indent_size)
+    # multi_arg && (s.indent += s.indent_size)
     for (i, a) in enumerate(x)
         n = pretty(a, s)
         if i == 1 && multi_arg
@@ -1045,7 +1047,7 @@ function p_braces(x, s)
             add_node!(t, n, join_lines=true)
         end
     end
-    multi_arg && (s.indent -= s.indent_size)
+    # multi_arg && (s.indent -= s.indent_size)
     t
 end
 
@@ -1055,7 +1057,7 @@ function p_vect(x, s)
     # [a,b]
     multi_arg = length(x) > 4
 
-    multi_arg && (s.indent += s.indent_size)
+    # multi_arg && (s.indent += s.indent_size)
     for (i, a) in enumerate(x)
         n = pretty(a, s)
         if i == 1 && multi_arg
@@ -1071,7 +1073,7 @@ function p_vect(x, s)
             add_node!(t, n, join_lines=true)
         end
     end
-    multi_arg && (s.indent -= s.indent_size)
+    # multi_arg && (s.indent -= s.indent_size)
     t
 end
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -695,10 +695,9 @@ function pretty(x::T, s::State; nonest=false) where T <: Union{CSTParser.BinaryO
         add_node!(t, whitespace)
     end
     
-    if CSTParser.defines_function(x)
-    end
-
+    CSTParser.defines_function(x) && (s.indent += s.indent_size)
     arg2 = x.arg2 isa T ? pretty(x.arg2, s, nonest=nonest) : pretty(x.arg2, s)
+    CSTParser.defines_function(x) && (s.indent -= s.indent_size)
     add_node!(t, arg2, join_lines=true)
     t
 end
@@ -816,7 +815,7 @@ function pretty(x::CSTParser.EXPR{T}, s::State) where T <: Union{CSTParser.Tuple
         multi_arg = true
     end
 
-    @info "" multi_arg typeof(x)
+    # @info "" multi_arg typeof(x)
 
     multi_arg && (s.indent += s.indent_size)
     for (i, a) in enumerate(x)

--- a/src/print.jl
+++ b/src/print.jl
@@ -30,15 +30,13 @@ function print_tree(io::IOBuffer, x::PTree, s::State)
 end
 
 function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{T}}, s::State) where T <: Union{CSTParser.Call,CSTParser.Curly,CSTParser.MacroCall}
-    @info "" x.indent x.nodes[1]
+    # @info "" x.indent x.nodes[1]
     ws = repeat(" ", x.indent)
     for (i, n) in enumerate(x.nodes)
         print_tree(io, n, s)
         if n === newline && i < length(x.nodes)
             if is_closer(x.nodes[i+1])
-                w = min(s.indent_size, length(x.nodes[1]) + length(x.nodes[2]))
-                # w = s.indent_size - x.indent % s.indent_size
-                write(io, ws[1:end-w])
+                write(io, repeat(" ", x.nodes[i+1].indent))
             elseif is_block(x.nodes[i+1])
                 write(io, repeat(" ", x.nodes[i+1].indent))
             elseif !skip_indent(x.nodes[i+1])
@@ -48,13 +46,14 @@ function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{T}}, s::State) where T
     end
 end
 
-function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{T}}, s::State) where T <: Union{CSTParser.TupleH,CSTParser.Braces,CSTParser.Vect}
+function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{T}}, s::State) where T <: Union{CSTParser.TupleH,CSTParser.Braces,CSTParser.Vect,CSTParser.InvisBrackets,CSTParser.Parameters}
+    # @info "" x.indent x.nodes[1]
     ws = repeat(" ", x.indent)
     for (i, n) in enumerate(x.nodes)
         print_tree(io, n, s)
         if n === newline && i < length(x.nodes)
             if is_closer(x.nodes[i+1])
-                write(io, ws[1:end-1])
+                write(io, repeat(" ", x.nodes[i+1].indent))
             elseif is_block(x.nodes[i+1])
                 write(io, repeat(" ", x.nodes[i+1].indent))
             elseif !skip_indent(x.nodes[i+1])
@@ -70,7 +69,7 @@ function print_tree(io::IOBuffer, x::PTree{CSTParser.WhereOpCall}, s::State)
         print_tree(io, n, s)
         if n === newline && i < length(x.nodes)
             if is_closer(x.nodes[i+1])
-                write(io, ws[1:end-1])
+                write(io, repeat(" ", x.nodes[i+1].indent))
             elseif is_block(x.nodes[i+1])
                 write(io, repeat(" ", x.nodes[i+1].indent))
             elseif !skip_indent(x.nodes[i+1])

--- a/src/print.jl
+++ b/src/print.jl
@@ -10,9 +10,9 @@ skip_indent(::NotCode) = true
 print_tree(io::IOBuffer, x::PLeaf, ::State) = write(io, x.text)
 print_tree(io::IOBuffer, ::Newline, ::State) = write(io, "\n")
 print_tree(io::IOBuffer, ::Semicolon, ::State) = write(io, ";")
-print_tree(io::IOBuffer, ::Whitespace, ::State) = write(io, " ")
+print_tree(io::IOBuffer, x::Whitespace, ::State) = write(io, repeat(" ", x.n))
+print_tree(io::IOBuffer, x::PlaceholderWS, ::State) = write(io, repeat(" ", x.n))
 print_tree(io::IOBuffer, ::Placeholder, ::State) = write(io, "")
-print_tree(io::IOBuffer, ::PlaceholderWS, ::State) = write(io, " ")
 print_tree(io::IOBuffer, x::TrailingComment, ::State) = write(io, x.text)
 
 function print_tree(io::IOBuffer, x::PTree, s::State)

--- a/src/print.jl
+++ b/src/print.jl
@@ -1,4 +1,3 @@
-
 is_block(_) = false
 is_block(::PTree{CSTParser.EXPR{CSTParser.Block}}) = true
 is_block(::PTree{CSTParser.EXPR{CSTParser.StringH}}) = true
@@ -14,6 +13,7 @@ print_tree(io::IOBuffer, ::Semicolon, ::State) = write(io, ";")
 print_tree(io::IOBuffer, ::Whitespace, ::State) = write(io, " ")
 print_tree(io::IOBuffer, ::Placeholder, ::State) = write(io, "")
 print_tree(io::IOBuffer, ::PlaceholderWS, ::State) = write(io, " ")
+print_tree(io::IOBuffer, x::TrailingComment, ::State) = write(io, x.text)
 
 function print_tree(io::IOBuffer, x::PTree, s::State)
     ws = repeat(" ", x.indent)
@@ -29,15 +29,15 @@ function print_tree(io::IOBuffer, x::PTree, s::State)
     end
 end
 
-function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{T}}, s::State; closer_indent=-1) where T <: Union{CSTParser.Call,CSTParser.Curly,CSTParser.MacroCall}
+function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{T}}, s::State) where T <: Union{CSTParser.Call,CSTParser.Curly,CSTParser.MacroCall}
+    @info "" x.indent x.nodes[1]
     ws = repeat(" ", x.indent)
     for (i, n) in enumerate(x.nodes)
         print_tree(io, n, s)
         if n === newline && i < length(x.nodes)
-            if is_closer(x.nodes[i+1]) && closer_indent != -1
-                write(io, ws[1:closer_indent])
-            elseif is_closer(x.nodes[i+1])
+            if is_closer(x.nodes[i+1])
                 w = min(s.indent_size, length(x.nodes[1]) + length(x.nodes[2]))
+                # w = s.indent_size - x.indent % s.indent_size
                 write(io, ws[1:end-w])
             elseif is_block(x.nodes[i+1])
                 write(io, repeat(" ", x.nodes[i+1].indent))
@@ -48,14 +48,12 @@ function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{T}}, s::State; closer_
     end
 end
 
-function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{T}}, s::State; closer_indent=-1) where T <: Union{CSTParser.TupleH,CSTParser.Braces,CSTParser.Vect}
+function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{T}}, s::State) where T <: Union{CSTParser.TupleH,CSTParser.Braces,CSTParser.Vect}
     ws = repeat(" ", x.indent)
     for (i, n) in enumerate(x.nodes)
         print_tree(io, n, s)
         if n === newline && i < length(x.nodes)
-            if is_closer(x.nodes[i+1]) && closer_indent != -1
-                write(io, ws[1:closer_indent])
-            elseif is_closer(x.nodes[i+1])
+            if is_closer(x.nodes[i+1])
                 write(io, ws[1:end-1])
             elseif is_block(x.nodes[i+1])
                 write(io, repeat(" ", x.nodes[i+1].indent))
@@ -79,29 +77,6 @@ function print_tree(io::IOBuffer, x::PTree{CSTParser.WhereOpCall}, s::State)
                 write(io, ws)
             end
         end
-    end
-end
-
-function print_tree(io::IOBuffer, x::PTree{T}, s::State) where T <: Union{CSTParser.BinaryOpCall,CSTParser.BinarySyntaxOpCall}
-    ws = repeat(" ", x.indent)
-    assign_op = false
-    for (i, n) in enumerate(x.nodes[1:end-1])
-        print_tree(io, n, s)
-        if n === newline && i < length(x.nodes)
-            if is_block(x.nodes[i+1])
-                write(io, repeat(" ", x.nodes[i+1].indent))
-            elseif !skip_indent(x.nodes[i+1])
-                write(io, ws)
-            end
-        elseif n isa PLeaf{CSTParser.OPERATOR}
-            assign_op = is_assignment(n)
-        end
-    end
-
-    if is_alignable(x.nodes[end]) && assign_op
-        print_tree(io, x.nodes[end], s, closer_indent=x.indent)
-    else
-        print_tree(io, x.nodes[end], s)
     end
 end
 

--- a/src/print.jl
+++ b/src/print.jl
@@ -105,33 +105,6 @@ function print_tree(io::IOBuffer, x::PTree{T}, s::State) where T <: Union{CSTPar
     end
 end
 
-function print_tree(io::IOBuffer, x::PTree{CSTParser.EXPR{CSTParser.If}}, s::State)
-    ws = repeat(" ", x.indent)
-    n1 = x.nodes[1]
-    for (i, n) in enumerate(x.nodes)
-        print_tree(io, n, s)
-        if n === newline && i < length(x.nodes)
-            if is_block(x.nodes[i+1])
-                write(io, repeat(" ", x.nodes[i+1].indent))
-            elseif x.nodes[i+1] isa PLeaf{CSTParser.KEYWORD}
-                v = x.nodes[i+1].text
-                if n1 isa PLeaf{CSTParser.KEYWORD} && n1.text == "if " 
-                    write(io, ws)
-                elseif v == "elseif" || v == "else"
-                    if ws != ""
-                        write(io, repeat(" ", x.indent - s.indent_size))
-                    end
-                else
-                    write(io, ws)
-                end
-            elseif !skip_indent(x.nodes[i+1])
-                write(io, ws)
-            end
-        end
-    end
-end
-
-
 function print_tree(io::IOBuffer, x::NotCode, s::State)
     ws = repeat(" ", x.indent)
     # `NotCode` nodes always follow a `Newline` node.

--- a/test/files/PProf.jl
+++ b/test/files/PProf.jl
@@ -32,36 +32,50 @@ using Base.StackTraces: lookup, StackFrame
 
 # TODO:
 # - Mappings
-# - Understand what Sample.value[0] is supposed to be
-# - Check that we add Locations in the right order.
-# - Tests!
 
 """
-    pprof(; outfile = "profile.pb.gz", drop_frames = "", keep_frames = "")
+    pprof(data, period; out = "profile.pb.gz", from_c = true, drop_frames = "", keep_frames = "")
 
 Fetches and converts `Profile` data to the `pprof` format.
 
 # Arguments:
+- `data::Vector{UInt}`: The data provided by `Profile.fetch` [optional].
+- `period::UInt64`: The sampling period in nanoseconds [optional].
+
+# Keyword Arguments
 - `out::String`: Filename for output.
+- `from_c::Bool`: If `false`, exclude frames that come from from_c. Defaults to `true`.
 - `drop_frames`: frames with function_name fully matching regexp string will be dropped from the samples,
                  along with their successors.
 - `keep_frames`: frames with function_name fully matching regexp string will be kept, even if it matches drop_functions.
 """
-function pprof(;out::AbstractString = "profile.pb.gz",
-                drop_frames::Union{Nothing, AbstractString} = nothing,
-                keep_frames::Union{Nothing, AbstractString} = nothing)
-    data   = copy(Profile.fetch())
-    period = ccall(:jl_profile_delay_nsec, UInt64, ())
+function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
+               period::Union{Nothing, UInt64} = nothing;
+               out::AbstractString = "profile.pb.gz",
+               from_c::Bool = true,
+               drop_frames::Union{Nothing, AbstractString} = nothing,
+               keep_frames::Union{Nothing, AbstractString} = nothing)
+    if data === nothing
+        data = copy(Profile.fetch())
+    end
+    if period === nothing
+        period = ccall(:jl_profile_delay_nsec, UInt64, ())
+    end
 
     string_table = OrderedDict{AbstractString, Int}()
     enter!(string) = _enter!(string_table, string)
+    enter!(::Nothing) = _enter!(string_table, "nothing")
     ValueType!(_type, unit) = ValueType(_type = enter!(_type), unit = enter!(unit))
 
     # Setup:
     enter!("")  # NOTE: pprof requires first entry to be ""
     # Functions need a uid, we'll use the pointer for the method instance
+    seen_funcs = Set{UInt64}()
     funcs = Dict{UInt64, Function}()
+
+    seen_locs = Set{UInt64}()
     locs  = Dict{UInt64, Location}()
+    locs_from_c  = Dict{UInt64, Bool}()
 
     sample_type = [
         ValueType!("events",      "count"), # Mandatory
@@ -70,8 +84,9 @@ function pprof(;out::AbstractString = "profile.pb.gz",
 
     prof = PProfile(
         sample = [], location = [], _function = [],
-        mapping = [], string_table = [], sample_type = sample_type,
-        period = period, period_type = ValueType!("cpu", "ns")
+        mapping = [], string_table = [],
+        sample_type = sample_type, default_sample_type = 1, # events
+        period = period, period_type = ValueType!("cpu", "nanoseconds")
     )
 
     if drop_frames !== nothing
@@ -110,46 +125,65 @@ function pprof(;out::AbstractString = "profile.pb.gz",
         # a single line of code and `litrace` has the necessary information to decode
         # that IP to a specific frame (or set of frames, if inlining occured).
 
-        push!(location_id, ip)
         # if we have already seen this IP avoid decoding it again
-        haskey(locs, ip) && continue
+        if ip in seen_locs
+            # Only keep C frames if from_c=true
+            if (from_c || !locs_from_c[ip])
+                push!(location_id, ip)
+            end
+            continue
+        end
+        push!(seen_locs, ip)
 
         # Decode the IP into information about this stack frame (or frames given inlining)
         location = Location(;id = ip, address = ip, line=[])
+        location_from_c = true
         for frame in lookup(ip)
             # ip 0 is reserved
             frame.pointer == 0 && continue
+            # if any of the frames is not from_c the entire location is not from_c
+            location_from_c &= frame.from_c
 
             push!(location.line, Line(function_id = frame.pointer, line = frame.line))
             # Known function
-            haskey(funcs, frame.pointer) && continue
+            frame.pointer in seen_funcs && continue
+            push!(seen_funcs, frame.pointer)
 
             # Store the function in our functions dict
             funcProto = Function()
             funcProto.id = frame.pointer
+            file = nothing
             if frame.linfo !== nothing && frame.linfo isa Core.MethodInstance
                 linfo = frame.linfo::Core.MethodInstance
                 meth = linfo.def
-                file = Base.find_source_file(string(meth.file))
+                file = string(meth.file)
                 funcProto.name       = enter!(string(meth.module, ".", meth.name))
-                funcProto.filename   = enter!(file)
                 funcProto.start_line = convert(Int64, meth.line)
             else
                 # frame.linfo either nothing or CodeInfo, either way fallback
-                file = Base.find_source_file(string(frame.file))
-                file_repr = file == nothing ? "nothing" : file
+                file = string(frame.file)
                 funcProto.name = enter!(string(frame.func))
-                funcProto.filename = enter!(file_repr)
                 funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
             end
+            file = Base.find_source_file(file)
+            funcProto.filename   = enter!(file)
             funcProto.system_name = funcProto.name
-            funcs[frame.pointer] = funcProto
+            # Only keep C functions if from_c=true
+            if (from_c || !frame.from_c)
+                funcs[frame.pointer] = funcProto
+            end
         end
-        locs[ip] = location
+        locs_from_c[ip] = location_from_c
+        # Only keep C frames if from_c=true
+        if (from_c || !location_from_c)
+            locs[ip] = location
+            push!(location_id, ip)
+        end
     end
 
     # Build Profile
     prof.string_table = collect(keys(string_table))
+    # If from_c=false funcs and locs should NOT contain C functions
     prof._function = collect(values(funcs))
     prof.location  = collect(values(locs))
 

--- a/test/files/PProf.jl
+++ b/test/files/PProf.jl
@@ -1,0 +1,164 @@
+module PProf
+
+export pprof
+
+using Profile
+using ProtoBuf
+using OrderedCollections
+
+include(joinpath("..", "lib", "perftools.jl"))
+
+import .perftools.profiles: ValueType, Sample, Function,
+                            Location, Line
+const PProfile = perftools.profiles.Profile
+
+"""
+    _enter!(dict::OrderedDict{T, Int}, key::T) where T
+
+Resolves from `key` to the index (zero-based) in the dict.
+Useful for the Strings table
+"""
+function _enter!(dict::OrderedDict{T, Int}, key::T) where T
+    if haskey(dict, key)
+        return dict[key]
+    else
+        l = length(dict)
+        dict[key] = l
+        return l
+    end
+end
+
+using Base.StackTraces: lookup, StackFrame
+
+# TODO:
+# - Mappings
+# - Understand what Sample.value[0] is supposed to be
+# - Check that we add Locations in the right order.
+# - Tests!
+
+"""
+    pprof(; outfile = "profile.pb.gz", drop_frames = "", keep_frames = "")
+
+Fetches and converts `Profile` data to the `pprof` format.
+
+# Arguments:
+- `out::String`: Filename for output.
+- `drop_frames`: frames with function_name fully matching regexp string will be dropped from the samples,
+                 along with their successors.
+- `keep_frames`: frames with function_name fully matching regexp string will be kept, even if it matches drop_functions.
+"""
+function pprof(;out::AbstractString = "profile.pb.gz",
+                drop_frames::Union{Nothing, AbstractString} = nothing,
+                keep_frames::Union{Nothing, AbstractString} = nothing)
+    data   = copy(Profile.fetch())
+    period = ccall(:jl_profile_delay_nsec, UInt64, ())
+
+    string_table = OrderedDict{AbstractString, Int}()
+    enter!(string) = _enter!(string_table, string)
+    ValueType!(_type, unit) = ValueType(_type = enter!(_type), unit = enter!(unit))
+
+    # Setup:
+    enter!("")  # NOTE: pprof requires first entry to be ""
+    # Functions need a uid, we'll use the pointer for the method instance
+    funcs = Dict{UInt64, Function}()
+    locs  = Dict{UInt64, Location}()
+
+    sample_type = [
+        ValueType!("events",      "count"), # Mandatory
+        ValueType!("stack_depth", "count")
+    ]
+
+    prof = PProfile(
+        sample = [], location = [], _function = [],
+        mapping = [], string_table = [], sample_type = sample_type,
+        period = period, period_type = ValueType!("cpu", "ns")
+    )
+
+    if drop_frames !== nothing
+        prof.drop_frames = enter!(drop_frames)
+    end
+    if keep_frames !== nothing
+        prof.keep_frames = enter!(keep_frames)
+    end
+
+    # start decoding backtraces
+    location_id = Vector{eltype(data)}()
+    lastwaszero = true
+
+    for ip in data
+        # ip == 0x0 is the sentinel value for finishing a backtrace, therefore finising a sample
+        if ip == 0
+            # Avoid creating empty samples
+            if lastwaszero
+                @assert length(location_id) == 0
+                continue
+            end
+
+            # End of sample
+            value = [
+                1,                   # events
+                length(location_id), # stack_depth
+            ]
+            push!(prof.sample, Sample(;location_id = location_id, value = value))
+            location_id = Vector{eltype(data)}()
+            lastwaszero = true
+            continue
+        end
+        lastwaszero = false
+
+        # A backtrace consists of a set of IP (Instruction Pointers), each IP points
+        # a single line of code and `litrace` has the necessary information to decode
+        # that IP to a specific frame (or set of frames, if inlining occured).
+
+        push!(location_id, ip)
+        # if we have already seen this IP avoid decoding it again
+        haskey(locs, ip) && continue
+
+        # Decode the IP into information about this stack frame (or frames given inlining)
+        location = Location(;id = ip, address = ip, line=[])
+        for frame in lookup(ip)
+            # ip 0 is reserved
+            frame.pointer == 0 && continue
+
+            push!(location.line, Line(function_id = frame.pointer, line = frame.line))
+            # Known function
+            haskey(funcs, frame.pointer) && continue
+
+            # Store the function in our functions dict
+            funcProto = Function()
+            funcProto.id = frame.pointer
+            if frame.linfo !== nothing && frame.linfo isa Core.MethodInstance
+                linfo = frame.linfo::Core.MethodInstance
+                meth = linfo.def
+                file = Base.find_source_file(string(meth.file))
+                funcProto.name       = enter!(string(meth.module, ".", meth.name))
+                funcProto.filename   = enter!(file)
+                funcProto.start_line = convert(Int64, meth.line)
+            else
+                # frame.linfo either nothing or CodeInfo, either way fallback
+                file = Base.find_source_file(string(frame.file))
+                file_repr = file == nothing ? "nothing" : file
+                funcProto.name = enter!(string(frame.func))
+                funcProto.filename = enter!(file_repr)
+                funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
+            end
+            funcProto.system_name = funcProto.name
+            funcs[frame.pointer] = funcProto
+        end
+        locs[ip] = location
+    end
+
+    # Build Profile
+    prof.string_table = collect(keys(string_table))
+    prof._function = collect(values(funcs))
+    prof.location  = collect(values(locs))
+
+    # Write to
+    open(out, "w") do io
+        writeproto(io, prof)
+    end
+
+    out
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1060,6 +1060,29 @@ end
     str = "(arg1)"
     @test format(str, 4, 1) == str
 
+    str_ = """
+    begin
+    if foo
+    elseif baz
+    elseif (a || b) && c
+    elseif bar
+    else
+    end
+    end"""
+
+    str = """
+    begin
+        if foo
+        elseif baz
+        elseif (a ||
+                b) && c
+        elseif bar
+        else
+        end
+    end"""
+    @test format(str_, 4, 21) == str
+    @test format(str_, 4, 19) == str
+
     str = """
     begin
         if foo
@@ -1071,17 +1094,7 @@ end
         else
         end
     end"""
-
-    str_ = """
-    begin
-    if foo
-    elseif baz
-    elseif (a || b) && c
-    elseif bar
-    else
-    end
-    end"""
-    @test format(str_, 4, 20) == str
+    @test format(str_, 4, 18) == str
 
     str = """
     begin
@@ -1093,17 +1106,8 @@ end
         else
         end
     end"""
-
-    str_ = """
-    begin
-    if foo
-    elseif baz
-    elseif (a || b) && c
-    elseif bar
-    else
-    end
-    end"""
     @test format(str_, 4, 23) == str
+    @test format(str_, 4, 22) == str
 
     str = """
     begin
@@ -1113,16 +1117,6 @@ end
         elseif bar
         else
         end
-    end"""
-
-    str_ = """
-    begin
-    if foo
-    elseif baz
-    elseif (a || b) && c
-    elseif bar
-    else
-    end
     end"""
     @test format(str_, 4, 24) == str
 
@@ -1194,7 +1188,7 @@ end
         \""",
         foo(b, c)
     )"""
-    @test format(str, 4, 31) == str
+    @test_broken format(str, 4, 31) == str
 
 
 end
@@ -1464,8 +1458,7 @@ end
     foo(a, b, c)::Rtype where {
         A,
         B
-    } =
-        10"""
+    } = 10"""
     @test format(str, 4, 32) == str_
     @test format(str, 4, 19) == str_
 
@@ -1477,8 +1470,7 @@ end
     )::Rtype where {
         A,
         B
-    } =
-        10"""
+    } = 10"""
     @test format(str, 4, 18) == str_
 
 
@@ -1490,8 +1482,5 @@ end
 #
 # add another check in binary function defs to see if lifting
 # the nested line back up again is possible
-# 
-# TODO: StringH should nest
-# TODO: 
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -321,7 +321,7 @@ end
       body
     end""") == str
 
-    # TODO: This should probably be aligned to match up with a
+    # TODO: This should probably be aligned to match up with a ?
     str = """
     let x = a,
     # comment
@@ -1167,22 +1167,36 @@ end
            :mesh_dim => Cint(3),)"""
     @test format(str_, 4, 80) == str
 
-    # TODO: only nest lazy calls if the parent is another binary call or an if statement
-    
     str = """
     begin
         a && b
         a || b
     end"""
     @test format(str, 4, 1) == str
+
+    # str = """
+    # func(a, \"""this
+    # is another
+    # multi-line
+    # string.
+    # Longest line
+    # \""", foo(b, c))"""
+    # @test format(str, 4, 33) == str
     
     str = """
     func(
         a,
-        "hello",
-        c
+        \"""this
+        is another
+        multi-line
+        string.
+        Longest line
+        \""",
+        foo(b, c)
     )"""
-    @test format("func(a,\"hello\",c)", 4, 1) == str
+    @test format(str, 4, 31) == str
+
+
 end
 
 @testset "nesting line offset" begin
@@ -1437,23 +1451,47 @@ end
     }"""
     @test format("f(var1::A, var2::B) where {A,B}", 4, 12) == str
 
+    str = "foo(a, b, c)::Rtype where {A,B} = 10"
+    @test format(str, 4, length(str)) == str
+
+    str_ = """
+    foo(a, b, c)::Rtype where {A,B} =
+        10"""
+    @test format(str, 4, 35) == str_
+    @test format(str, 4, 33) == str_
+
+    str_ = """
+    foo(a, b, c)::Rtype where {
+        A,
+        B
+    } =
+        10"""
+    @test format(str, 4, 32) == str_
+    @test format(str, 4, 19) == str_
+
+    str_ = """
+    foo(
+        a,
+        b,
+        c
+    )::Rtype where {
+        A,
+        B
+    } =
+        10"""
+    @test format(str, 4, 18) == str_
+
+
 end
 
-# TODO:
 #
+# TODO: not sure how this should be formatted, revisit at some point
 # push!(s::BitSet, ns::Integer...) = (for n in ns; push!(s, n); end; s)
 #
-# function foo(a)::R where {A,B}
-#     10
-# end
-#
-# need to add a check in p_binarycall
-# foo(a)::R where {A,B} = 10
+# add another check in binary function defs to see if lifting
+# the nested line back up again is possible
 # 
-# StringH should nest
-#
-# @propagate_inbounds function Base.iterate(v::T, i::Union{Int,Nothing}=v.dict.idxfloor) where T <: Union{KeySet{<:Any, <:Dict}, ValueIterator{<:Dict}}	end
-#
-# Base.@propagate_inbounds function _broadcast_getindex(bc::Broadcasted{<:Any,<:Any,<:Any,<:Tuple{Ref{Type{T}},Ref{Type{S}},Vararg{Any}}}, I) where {T,S} end
+# TODO: StringH should nest
+# TODO: 
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -861,7 +861,7 @@ end
         10
         20
     end"""
-    @test format("function f(arg1::A,key1=val1;key2=val2) where {A,F{B,C}} 10; 20 end", 4, 26) == str
+    @test format("function f(arg1::A,key1=val1;key2=val2) where {A,F{B,C}} 10; 20 end", 4, 17) == str
 
     str = """
     function f(
@@ -872,7 +872,7 @@ end
         10
         20
     end"""
-    @test format("function f(arg1::A,key1=val1;key2=val2) where {A,F{B,C}} 10; 20 end", 4, 27) == str
+    @test format("function f(arg1::A,key1=val1;key2=val2) where {A,F{B,C}} 10; 20 end", 4, 18) == str
 
     str = """
     a |
@@ -1105,13 +1105,14 @@ end
            :mesh_dim => Cint(3),)"""
     @test format(str_, 4, 80) == str
 
+    # TODO: revisit
     # don't nest lazy calls unless they are part of an if statement
-    str = """
-    begin
-        a && b
-        a || b
-    end"""
-    @test_broken format(str) == str
+    # str = """
+    # begin
+    #     a && b
+    #     a || b
+    # end"""
+    # @test_broken format(str) == str
 end
 
 @testset "nesting line offset" begin
@@ -1209,9 +1210,9 @@ end
             x_ => (x, :Any)
         end"""
     s = run_nest(str, 96)
-    @test s.line_offset == 3
+    @test s.line_offset == 7
     s = run_nest(str, 1)
-    @test s.line_offset == 3
+    @test s.line_offset == 7
 
     str = "prettify(ex; lines = false) = ex |> (lines ? identity : striplines) |> flatten |> unresolve |> resyntax |> alias_gensyms"
     s = run_nest(str, 80)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1360,4 +1360,27 @@ end
 
 end
 
+# TODO:
+#
+# throw_overflowerr_binaryop(op, x, y) = (@_noinline_meta;	throw_overflowerr_binaryop(op, x, y) =
+#     throw(OverflowError(Base.invokelatest(string, x, " ", op, " ", y, " overflowed for type ", typeof(x)))))
+#
+# push!(s::BitSet, ns::Integer...) = (for n in ns; push!(s, n); end; s)
+#
+# src[a+=1] -> src[a += 1]
+#
+# T <: A -> T<:A
+#
+# function foo(a)::R where {A,B}
+# end
+# 
+# strings
+#
+# propagate indent to front of the line
+#
+# don't nest shortcut binary ops &&, ||
+#
+# Val(x) = (@_pure_meta ; Val{x}())	-> Val(x) = (@_pure_meta; Val{x}())	
+# primitive type WindowsRawSocket sizeof(Ptr) * 8 end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1108,6 +1108,14 @@ end
            :numberofpointmtrs => NMTr, :numberofcorners => NSimplex, :firstnumber => Cint(1), 
            :mesh_dim => Cint(3),)"""
     @test format(str_, 4, 80) == str
+
+    # don't nest lazy calls unless they are part of an if statement
+    str = """
+    begin
+        a && b
+        a || b
+    end"""
+    @test format(str) == str
 end
 
 @testset "nesting line offset" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -834,16 +834,16 @@ end
 @testset "nesting" begin
     str = """
     function f(
-               arg1::A,
-               key1=val1;
-               key2=val2
-             ) where {
-                      A,
-                      F{
-                        B,
-                        C
-                      }
-                     }
+        arg1::A,
+        key1=val1;
+        key2=val2
+    ) where {
+        A,
+        F{
+          B,
+          C
+        }
+    }
         10
         20
     end"""
@@ -851,25 +851,24 @@ end
 
     str = """
     function f(
-               arg1::A,
-               key1=val1;
-               key2=val2
-             ) where {
-                      A,
-                      F{B,C}
-                     }
+        arg1::A,
+        key1=val1;
+        key2=val2
+    ) where {
+        A,
+        F{B,C}
+    }
         10
         20
     end"""
-
     @test format("function f(arg1::A,key1=val1;key2=val2) where {A,F{B,C}} 10; 20 end", 4, 26) == str
 
     str = """
     function f(
-               arg1::A,
-               key1=val1;
-               key2=val2
-             ) where {A,F{B,C}}
+        arg1::A,
+        key1=val1;
+        key2=val2
+    ) where {A,F{B,C}}
         10
         20
     end"""
@@ -978,9 +977,9 @@ end
         (
          one,
          x -> (
-               true,
-               false
-              )
+             true,
+             false
+         )
         )"""
     @test format("foo() = (one, x -> (true, false))", 4, 20) == str
 
@@ -990,6 +989,9 @@ end
         body_
     end"""
     @test format("@somemacro function (fcall_ | fcall_) body_ end", 4, 1) == str
+    
+    str = "Val(x) = (@_pure_meta; Val{x}())"
+    @test format("Val(x) = (@_pure_meta ; Val{x}())", 4, 80) == str
 
     str = "(a; b; c)"
     @test format("(a;b;c)", 4, 100) == str
@@ -1016,26 +1018,20 @@ end
 
     # don't nest < 2 args
     
-    str = """
-    A where {B}"""
+    str = "A where {B}"
     @test format(str, 4, 1) == str
 
-    str = """
-    foo(arg1)"""
+    str = "foo(arg1)"
     @test format(str, 4, 1) == str
 
-    str = """
-    [arg1]"""
+    str = "[arg1]"
     @test format(str, 4, 1) == str
 
-    str = """
-    {arg1}"""
+    str = "{arg1}"
     @test format(str, 4, 1) == str
 
-    str = """
-    (arg1)"""
+    str = "(arg1)"
     @test format(str, 4, 1) == str
-
 
     str = """
     begin
@@ -1115,7 +1111,7 @@ end
         a && b
         a || b
     end"""
-    @test format(str) == str
+    @test_broken format(str) == str
 end
 
 @testset "nesting line offset" begin
@@ -1157,9 +1153,9 @@ end
     s = run_nest(str, length(str)-1)
     @test s.line_offset == 15
     s = run_nest(str, 14)
-    @test s.line_offset == 9
+    @test s.line_offset == 1
     s = run_nest(str, 1)
-    @test s.line_offset == 9
+    @test s.line_offset == 1
 
     str = "f(a, b, c) where Union{A,B,C}"
     s = run_nest(str, 100)
@@ -1167,9 +1163,9 @@ end
     s = run_nest(str, length(str)-1)
     @test s.line_offset == 20
     s = run_nest(str, 19)
-    @test s.line_offset == 9
+    @test s.line_offset == 1
     s = run_nest(str, 1)
-    @test s.line_offset == 9
+    @test s.line_offset == 1
 
     str = "f(a, b, c) where A"
     s = run_nest(str, 100)
@@ -1189,15 +1185,15 @@ end
     s = run_nest(str, length(str)-1)
     @test s.line_offset == 31
     s = run_nest(str, 30)
-    @test s.line_offset == 9
+    @test s.line_offset == 1
     s = run_nest(str, 1)
-    @test s.line_offset == 9
+    @test s.line_offset == 1
 
     str = "f(a, b, c) where {A,{B,C,D},E}"
     s = run_nest(str, 100)
     @test s.line_offset == length(str)
     s = run_nest(str, 1)
-    @test s.line_offset == 9
+    @test s.line_offset == 1
 
     str = "(a, b, c, d)"
     s = run_nest(str, 100)
@@ -1361,21 +1357,16 @@ end
       var1::A,
       var2::B
     ) where {
-             A,
-             B
-            }"""
+        A,
+        B
+    }"""
     @test format("f(var1::A, var2::B) where {A,B}", 4, 12) == str
 
 end
 
 # TODO:
 #
-# throw_overflowerr_binaryop(op, x, y) = (@_noinline_meta;	throw_overflowerr_binaryop(op, x, y) =
-#     throw(OverflowError(Base.invokelatest(string, x, " ", op, " ", y, " overflowed for type ", typeof(x)))))
-#
 # push!(s::BitSet, ns::Integer...) = (for n in ns; push!(s, n); end; s)
-#
-# src[a+=1] -> src[a += 1]
 #
 # T <: A -> T<:A
 #
@@ -1384,11 +1375,5 @@ end
 # 
 # strings
 #
-# propagate indent to front of the line
-#
-# don't nest shortcut binary ops &&, ||
-#
-# Val(x) = (@_pure_meta ; Val{x}())	-> Val(x) = (@_pure_meta; Val{x}())	
-# primitive type WindowsRawSocket sizeof(Ptr) * 8 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,15 +84,6 @@ end
     @test format("(a;)") == "(a)"
 end
 
-@testset "colon op" begin
-    @test format("a:b:c") == "a:b:c"
-    @test format("a:b:c") == "a:b:c"
-    @test format("a:b:c") == "a:b:c"
-    @test format("a:b:c") == "a:b:c"
-    @test format("a:b:c") == "a:b:c"
-    @test format("a:b:c") == "a:b:c"
-end
-
 @testset "func call" begin
     @test format("func(a, b, c)") == "func(a, b, c)"
     @test format("func(a,b,c)") == "func(a, b, c)"
@@ -184,7 +175,6 @@ end
       y = 20
                         return x * y
         end""") == str
-
 end
 
 @testset "for" begin
@@ -484,19 +474,20 @@ end
     \"""
     Interpolate using `\\\$`
     \"""
-    """
+    a"""
     @test format(str) == str
 
     str = """error("foo\\n\\nbar")"""
     @test format(str) == str
 
-    str = """
-    func(
-        a,
-        "hello",
-        c
-    )"""
-    @test format("func(a,\"hello\",c)", 4, 1) == str
+    # nesting
+    # str = """
+    # func(
+    #     a,
+    #     "hello",
+    #     c
+    # )"""
+    # @test format("func(a,\"hello\",c)", 4, 1) == str
 
     str = """
     \"""
@@ -601,7 +592,6 @@ end
 end
 
 @testset "pretty" begin
-
     str = """function foo end"""
     @test format("""
         function  foo
@@ -1373,8 +1363,15 @@ end
 #
 # function foo(a)::R where {A,B}
 # end
+#
+# need to add a check in p_binarycall
+# foo(a::A, b::B)::R where {A,B}
 # 
 # strings
 #
+# @propagate_inbounds function Base.iterate(v::T, i::Union{Int,Nothing}=v.dict.idxfloor) where T <: Union{KeySet{<:Any, <:Dict}, ValueIterator{<:Dict}}	
+#
+# Base.@propagate_inbounds function _broadcast_getindex(bc::Broadcasted{<:Any,<:Any,<:Any,<:Tuple{Ref{Type{T}},Ref{Type{S}},Vararg{Any}}}, I) where {T,S}
+# end
 
 end


### PR DESCRIPTION
Updates to use CSTParser v0.6 and refactor data structure to basically act as a CSTParser node with additional information relevant to formatting. Due to this restructuring everything is much faster.

Other improvements:

- binary calls are un-nested when possible
- no spaces are sub/super type ops if in a part of a `Curly` node
- lazy ops only nest if part of an if statement, i.e. `a = b || c` won't nest.
- inline comments #4 are supported. In some edge cases it's still deleted.
- nesting works much more intuitively, fixes and expands on #9 
- more stuff I probably forgot, so many fixes...