### PR TITLE
Don't adjust comments

### DIFF
--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -119,11 +119,7 @@ code as another string. The formatting options are:
 - `margin` which defaults to 92 columns
 
 """
-function format_text(
-    text::AbstractString;
-    indent::Integer = 4,
-    margin::Integer = 92,
-)
+function format_text(text::AbstractString; indent::Integer = 4, margin::Integer = 92,)
     if isempty(text)
         return text
     end
@@ -183,9 +179,7 @@ be written to `foo_fmt.jl` instead.
 """
 function format_file(
     filename::AbstractString;
-    indent::Integer = 4,
-    margin::Integer = 92,
-    overwrite::Bool = true,
+    indent::Integer = 4, margin::Integer = 92, overwrite::Bool = true,
 )
     path, ext = splitext(filename)
     if ext != ".jl"
@@ -228,4 +222,4 @@ function format(paths; options...)
 end
 format(path::AbstractString; options...) = format((path,); options...)
 
-end # module
+end

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -136,9 +136,8 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
     add_node!(t, InlineComment(t.endline))
     nest!(t, s)
 
-    # @debug "" t
-
     io = IOBuffer()
+
     # Print comments and whitespace before code.
     if t.startline > 1
         print_tree(io, Notcode(1, t.startline - 1), s)
@@ -149,6 +148,7 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
         add_node!(t, Newline())
         add_node!(t, Notcode(t.endline + 1, length(s.doc.ranges)))
     end
+
     print_tree(io, t, s)
 
     text = String(take!(io))

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -12,7 +12,7 @@ struct Document
     text::AbstractString
 
     ranges::Vector{UnitRange{Int}}
-    line_to_range::Dict{Int, UnitRange{Int}}
+    line_to_range::Dict{Int,UnitRange{Int}}
 
     # mapping the offset in the file to the raw literal
     # string and what lines it starts and ends at.

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -84,6 +84,13 @@ State(doc, indent_size, margin) = State(doc, indent_size, 0, 1, 0, margin)
 
 @inline nspaces(s::State) = s.indent
 
+@inline function getline(d::Document, line::Int)
+    for (l, r) in enumerate(d.ranges)
+        l == line && return d.text[r]
+    end
+    error("$(line) not found in file")
+end
+
 @inline function cursor_loc(s::State, offset::Int)
     for (l, r) in enumerate(s.doc.ranges)
         if offset in r
@@ -137,7 +144,7 @@ function format_text(
     io = IOBuffer()
     # Print comments and whitespace before code.
     if t.startline > 1
-        print_tree(io, Notcode(1, t.startline - 1, 0), s)
+        print_tree(io, Notcode(1, t.startline - 1), s)
         print_tree(io, Newline(), s)
     end
 
@@ -146,7 +153,7 @@ function format_text(
     # Print comments and whitespace after code.
     if t.endline < length(s.doc.ranges)
         print_tree(io, Newline(), s)
-        print_tree(io, Notcode(t.endline + 1, length(s.doc.ranges), 0), s)
+        print_tree(io, Notcode(t.endline + 1, length(s.doc.ranges)), s)
     end
 
     text = String(take!(io))

--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -133,6 +133,7 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
 
     s = State(d, indent, margin)
     t = pretty(x, s)
+    add_node!(t, InlineComment(t.endline))
     nest!(t, s)
 
     # @debug "" t
@@ -144,13 +145,11 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
         print_tree(io, Newline(), s)
     end
 
-    print_tree(io, t, s)
-
-    # Print comments and whitespace after code.
     if t.endline < length(s.doc.ranges)
-        print_tree(io, Newline(), s)
-        print_tree(io, Notcode(t.endline + 1, length(s.doc.ranges)), s)
+        add_node!(t, Newline())
+        add_node!(t, Notcode(t.endline + 1, length(s.doc.ranges)))
     end
+    print_tree(io, t, s)
 
     text = String(take!(io))
     _, ps = CSTParser.parse(CSTParser.ParseState(text), true)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -452,8 +452,8 @@ function p_macrocall(x, s)
             t,
             PTree(
                 CSTParser.LITERAL,
-                loc[1]-1,
-                loc[1]-1,
+                loc[1] - 1,
+                loc[1] - 1,
                 nspaces(s),
                 3,
                 "\"\"\"",

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -452,8 +452,8 @@ function p_macrocall(x, s)
             t,
             PTree(
                 CSTParser.LITERAL,
-                loc[1],
-                loc[1],
+                loc[1]-1,
+                loc[1]-1,
                 nspaces(s),
                 3,
                 "\"\"\"",

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -24,8 +24,8 @@ Newline() = PTree(NEWLINE, -1, -1, 0, 0, "\n", nothing, nothing)
 Semicolon() = PTree(SEMICOLON, -1, -1, 0, 1, ";", nothing, nothing)
 Whitespace(n) = PTree(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing)
 Placeholder(n) = PTree(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing)
-Notcode(startline, endline, indent) =
-    PTree(NOTCODE, startline, endline, indent, 0, "", nothing, nothing)
+Notcode(startline, endline) =
+    PTree(NOTCODE, startline, endline, 0, 0, "", nothing, nothing)
 InlineComment(line) = PTree(INLINECOMMENT, line, line, 0, 0, "", nothing, nothing)
 
 Base.length(x::PTree) = x.len
@@ -84,11 +84,7 @@ function add_node!(t::PTree, n; join_lines = false)
 
         if notcode_startline <= notcode_endline && n.typ !== CSTParser.LITERAL
             add_node!(t, Newline())
-            if !is_leaf(n)
-                add_node!(t, Notcode(notcode_startline, notcode_endline, n.indent))
-            else
-                add_node!(t, Notcode(notcode_startline, notcode_endline, t.indent))
-            end
+            add_node!(t, Notcode(notcode_startline, notcode_endline))
         end
 
         add_node!(t, Newline())
@@ -333,7 +329,7 @@ function p_literal(x, s; include_quotes = true)
         return PTree(x, loc[1], loc[1], x.val)
     end
 
-    # Strings are unescaped to by CSTParser
+    # Strings are unescaped by CSTParser
     # to mimic Meta.parse which makes reproducing
     # the correct output from the LITERAL value problematic.
     # So we'll just look at the source directly!

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -24,8 +24,7 @@ Newline() = PTree(NEWLINE, -1, -1, 0, 0, "\n", nothing, nothing)
 Semicolon() = PTree(SEMICOLON, -1, -1, 0, 1, ";", nothing, nothing)
 Whitespace(n) = PTree(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing)
 Placeholder(n) = PTree(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing)
-Notcode(startline, endline) =
-    PTree(NOTCODE, startline, endline, 0, 0, "", nothing, nothing)
+Notcode(startline, endline) = PTree(NOTCODE, startline, endline, 0, 0, "", nothing, nothing)
 InlineComment(line) = PTree(INLINECOMMENT, line, line, 0, 0, "", nothing, nothing)
 
 Base.length(x::PTree) = x.len

--- a/src/print.jl
+++ b/src/print.jl
@@ -45,35 +45,28 @@ function print_tree(io::IOBuffer, x::PTree, s::State)
     end
 end
 
-function print_notcode(io, x, s)
-    ws = repeat(" ", x.indent)
-    # `NOTCODE` nodes always follow a `NEWLINE` node.
+@inline function print_notcode(io, x, s)
     prev_nl = true
     for l in x.startline:x.endline
-        v = get(s.doc.comments, l, "\n")
-        # if l == x.startline && v != "\n"
-        #     write(io, ws)
-        if l == x.endline && v != "\n"
-            write(io, ws)
-            write(io, v[1:end])
-        elseif l == x.endline && v == "\n"
-        elseif v == "\n"
-            write(io, v)
-            !prev_nl && (write(io, ws))
-            prev_nl = true
-        else
-            write(io, ws)
-            write(io, v)
-            write(io, "\n")
-            prev_nl = false
+        v = getline(s.doc, l)
+        v == "" && continue
+        # @info "comment line" l v
+        if l == x.endline && v[end] == '\n'
+            v = v[1:end-1]
         end
+        write(io, v)
+        prev_nl = v == "\n" ? true : false
     end
 end
 
-function print_inlinecomment(io, x, s)
+@inline function print_inlinecomment(io, x, s)
     v = get(s.doc.comments, x.startline, "")
-    v == "" && (return)
-    write(io, " ")
+    v == "" && return
+    v = getline(s.doc, x.startline)
+    idx = findlast(c -> c == '#', v)
+    idx === nothing && return
+    idx = findlast(c -> !isspace(c), v[1:idx-1])
+    v = v[idx+1:end-1]
     write(io, v)
 end
 

--- a/src/print.jl
+++ b/src/print.jl
@@ -66,7 +66,7 @@ end
     idx = findlast(c -> c == '#', v)
     idx === nothing && return
     idx = findlast(c -> !isspace(c), v[1:idx-1])
-    v = v[idx+1:end-1]
+    v = v[end] == '\n' ? v[idx+1:end-1] : v[idx+1:end]
     write(io, v)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,7 +107,6 @@ end
 
     @testset "single line block" begin
         @test fmt("(a;b;c)") == "(a; b; c)"
-    # @test fmt("(a;)") == "(a)"
     end
 
     @testset "func call" begin
@@ -326,7 +325,7 @@ end
         # TODO: This should probably be aligned to match up with `a` ?
         str = """
         let x = a,
-        # comment
+            # comment
         b,
         c
             body
@@ -511,7 +510,6 @@ end
         end""") == str
 
         # test aligning to function identation
-        #
         @test fmt("""
             "doc"
         function f()
@@ -641,6 +639,7 @@ end
         end
 
         end"""
+        @test fmt(str) == str
 
         str_ = """
         module Foo
@@ -663,8 +662,29 @@ end
         end
 
         end"""
+        str = """
+        module Foo
+        # comment 0
+        # comment 1
+        begin
+
+        # comment 2
+        # comment 3
+
+            begin
+
+
+
+        # comment 4
+        # comment 5
+                a = 10
+            end
+
+        end
+
+        end"""
+
         @test fmt(str_) == str
-        @test fmt(str) == str
 
         str = "# comment 0\n\n\n\n\na = 1\n\n# comment 1\n\n\n\n\nb = 2\n\n\nc = 3\n\n# comment 2\n\n"
         @test fmt(str) == str
@@ -677,8 +697,6 @@ end
         const a = \"hi there\""""
         @test fmt(str) == str
 
-        # This currently aligns
-        # "comment below var" with else
         str = """
         if a
             # comment above var
@@ -687,7 +705,19 @@ end
         else
             something_else()
         end"""
-        @test_broken fmt(str) == str
+        @test fmt(str) == str
+
+        str = """
+        begin
+            a = 10 # foo
+            b = 20           # foo
+        end"""
+        str_ = """
+        begin
+        a = 10 # foo
+        b = 20           # foo
+        end"""
+        @test fmt(str_) == str
     end
 
     @testset "pretty" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -711,12 +711,12 @@ end
         begin
             a = 10 # foo
             b = 20           # foo
-        end"""
+        end    # trailing comment"""
         str_ = """
         begin
         a = 10 # foo
         b = 20           # foo
-        end"""
+        end    # trailing comment"""
         @test fmt(str_) == str
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -521,6 +521,15 @@ end
                  \"""
                  Foo"""
         @test fmt("\"\"\"doc for Foo\"\"\"\nFoo") == str
+
+        str = """
+        \"""
+        doc
+        \"""
+        function f()    #  comment
+            20
+        end"""
+        @test fmt(str) == str
     end
 
     @testset "strings" begin


### PR DESCRIPTION
Previously we attempted indenting comments to align with code. This worked most of the time, but not all of the time. In that case the comment would be incorrectly indented -/+ by one level. Additionally, inline comments would be altered such that they always began one space after the code.

In this PR we just leave comments as they are in the original source file. This makes Jeff happier and is less work so we should have just done this from the start 😄 