### PR TITLE
Remove unnecessary indent adjustments in pretty.jl

### DIFF
--- a/src/nest.jl
+++ b/src/nest.jl
@@ -219,7 +219,6 @@ function n_call!(x, s; extra_width = 0)
     idx = findlast(n -> n.typ === PLACEHOLDER, x.nodes)
     # @debug "ENTERING" s.line_offset x.typ length(x) extra_width
     if idx !== nothing && line_width > s.margin
-
         x.nodes[end].indent = x.indent
         line_offset = s.line_offset
 
@@ -396,9 +395,11 @@ function n_binarycall!(x, s; extra_width = 0)
         if CSTParser.defines_function(x.ref[])
             s.line_offset = x.indent + s.indent_size
             x.nodes[idx] = Whitespace(s.indent_size)
+            add_indent!(x.nodes[end], s, s.indent_size)
         else
             x.indent = s.line_offset
         end
+
 
         # arg2
         nest!(x.nodes[end], s, extra_width = extra_width)
@@ -419,6 +420,7 @@ function n_binarycall!(x, s; extra_width = 0)
         if line_width <= s.margin
             x.nodes[idx-1] = Whitespace(1)
             x.nodes[idx] = Placeholder(0)
+            add_indent!(x.nodes[end], s, -s.indent_size)
         end
 
         walk(reset_line_offset!, x, s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -481,11 +481,9 @@ function p_macrocall(x, s)
         elseif is_opener(n)
             add_node!(t, n, join_lines = true)
             add_node!(t, Placeholder(0))
-            s.indent += s.indent_size
         elseif is_closer(n)
             add_node!(t, Placeholder(0))
             add_node!(t, n, join_lines = true)
-            s.indent -= s.indent_size
         elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])
             add_node!(t, n, join_lines = true)
             add_node!(t, Placeholder(1))
@@ -921,7 +919,6 @@ function p_binarycall(x, s; nonest = false, nospace = false)
     end
 
 
-    CSTParser.defines_function(x) && (s.indent += s.indent_size)
     if x.args[3].typ === CSTParser.BinaryOpCall
         n = p_binarycall(x.args[3], s, nonest = nonest, nospace = nospace)
     elseif x.args[3].typ === CSTParser.InvisBrackets
@@ -929,7 +926,6 @@ function p_binarycall(x, s; nonest = false, nospace = false)
     else
         n = pretty(x.args[3], s)
     end
-    CSTParser.defines_function(x) && (s.indent -= s.indent_size)
     add_node!(t, n, join_lines = true)
     t
 end
@@ -1007,14 +1003,12 @@ function p_curly(x, s)
 
     if multi_arg
         add_node!(t, Placeholder(0))
-        s.indent += s.indent_size
     end
 
     for (i, a) in enumerate(x.args[3:end])
         if i + 2 == length(x) && multi_arg
             add_node!(t, Placeholder(0))
             add_node!(t, pretty(a, s), join_lines = true)
-            s.indent -= s.indent_size
         elseif CSTParser.is_comma(a) && i < length(x) - 3 && !is_punc(x.args[i+1])
             add_node!(t, pretty(a, s), join_lines = true)
             add_node!(t, Placeholder(0))
@@ -1034,14 +1028,12 @@ function p_call(x, s)
 
     if multi_arg
         add_node!(t, Placeholder(0))
-        s.indent += s.indent_size
     end
 
     for (i, a) in enumerate(x.args[3:end])
         if i + 2 == length(x) && multi_arg
             add_node!(t, Placeholder(0))
             add_node!(t, pretty(a, s), join_lines = true)
-            s.indent -= s.indent_size
         elseif CSTParser.is_comma(a) && i < length(x) - 3 && !is_punc(x.args[i+1])
             add_node!(t, pretty(a, s), join_lines = true)
             add_node!(t, Placeholder(1))
@@ -1057,7 +1049,6 @@ function p_invisbrackets(x, s; nonest = false, nospace = false)
     t = PTree(x, nspaces(s))
     multi_arg = length(x) > 4
 
-    # multi_arg && (s.indent += s.indent_size)
     for (i, a) in enumerate(x)
         if a.typ === CSTParser.Block
             add_node!(t, p_block(a, s, from_quote = true), join_lines = true)
@@ -1086,7 +1077,6 @@ function p_invisbrackets(x, s; nonest = false, nospace = false)
             add_node!(t, pretty(a, s), join_lines = true)
         end
     end
-    # multi_arg && (s.indent -= s.indent_size)
     t
 end
 
@@ -1100,7 +1090,6 @@ function p_tuple(x, s)
         multi_arg = true
     end
 
-    # multi_arg && (s.indent += s.indent_size)
     for (i, a) in enumerate(x)
         n = pretty(a, s)
         if is_opener(n) && multi_arg
@@ -1116,7 +1105,6 @@ function p_tuple(x, s)
             add_node!(t, n, join_lines = true)
         end
     end
-    # multi_arg && (s.indent -= s.indent_size)
     t
 end
 
@@ -1127,7 +1115,6 @@ function p_braces(x, s)
     multi_arg = length(x) > 4
     # @debug "" multi_arg typeof(x)
 
-        # multi_arg && (s.indent += s.indent_size)
     for (i, a) in enumerate(x)
         n = pretty(a, s)
         if i == 1 && multi_arg
@@ -1143,7 +1130,6 @@ function p_braces(x, s)
             add_node!(t, n, join_lines = true)
         end
     end
-    # multi_arg && (s.indent -= s.indent_size)
     t
 end
 
@@ -1153,7 +1139,6 @@ function p_vect(x, s)
     # [a,b]
     multi_arg = length(x) > 4
 
-    # multi_arg && (s.indent += s.indent_size)
     for (i, a) in enumerate(x)
         n = pretty(a, s)
         if i == 1 && multi_arg
@@ -1169,7 +1154,6 @@ function p_vect(x, s)
             add_node!(t, n, join_lines = true)
         end
     end
-    # multi_arg && (s.indent -= s.indent_size)
     t
 end
 

--- a/src/print.jl
+++ b/src/print.jl
@@ -1,4 +1,4 @@
-is_block(x) = x.typ === CSTParser.Block #|| x.typ === CSTParser.StringH
+is_block(x) = x.typ === CSTParser.Block
 
 function skip_indent(x)
     if x.typ === CSTParser.LITERAL && x.val == ""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1472,7 +1472,7 @@ end
                 x_ => (x, :Any)
             end"""
         s = run_nest(str, 96)
-        @test s.line_offset == 7
+        @test s.line_offset == 3
         s = run_nest(str, 1)
         @test s.line_offset == 7
 
@@ -1487,6 +1487,38 @@ end
         @test s.line_offset == 9
         s = run_nest(str, 1)
         @test s.line_offset == 5
+
+        str_ = """
+        @Expr(:scope_block, begin
+                    body1
+                    @Expr :break loop_cont
+                    body2
+                    @Expr :break loop_exit2
+                    body3
+                end)"""
+
+        str = """
+        @Expr(:scope_block, begin
+            body1
+            @Expr :break loop_cont
+            body2
+            @Expr :break loop_exit2
+            body3
+        end)"""
+        @test fmt(str_, 4, 100) == str
+
+        str = """
+        @Expr(
+            :scope_block,
+            begin
+                body1
+                @Expr :break loop_cont
+                body2
+                @Expr :break loop_exit2
+                body3
+            end
+        )"""
+        @test fmt(str_, 4, 50) == str
 
 
         str = "export @esc, isexpr, isline, iscall, rmlines, unblock, block, inexpr, namify, isdef"


### PR DESCRIPTION
There were some unnecessary indent adjustments in `pretty.jl` that caused sub-optimal indentation.

Example text

```
@Expr(:scope_block, begin
                    body1
                    @Expr :break loop_cont
                    body2
                    @Expr :break loop_exit2
                    body3
                end)
```

master:

```
@Expr(:scope_block, begin
        body1
        @Expr :break loop_cont
        body2
        @Expr :break loop_exit2
        body3
    end)

```

this branch:

```
@Expr(:scope_block, begin
    body1
    @Expr :break loop_cont
    body2
    @Expr :break loop_exit2
    body3
end)

```